### PR TITLE
feat: make directory if it doesn't exist when write files

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,8 +52,13 @@ exports.checkUrlForm = checkUrlForm;
 function writeFiles(paths, strs) {
     const currentDir = process.cwd();
     for (let i = 0; i < paths.length; i++) {
-        fs_1.default.writeFile(path_1.default.join(currentDir, paths[i]), strs[i], () => {
-            console.info(`[${path_1.default.join(currentDir, paths[i])}] was generated!`);
+        const filePath = path_1.default.join(currentDir, paths[i]);
+        const directoryPath = path_1.default.dirname(filePath);
+        if (!fs_1.default.existsSync(directoryPath)) {
+            fs_1.default.mkdirSync(directoryPath, { recursive: true });
+        }
+        fs_1.default.writeFile(filePath, strs[i], () => {
+            console.info(`[${filePath}] was generated!`);
         });
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,8 +44,13 @@ export function checkUrlForm(strUrl: string): boolean {
 export function writeFiles(paths: string[], strs: string[]) {
   const currentDir = process.cwd();
   for (let i=0; i<paths.length; i++) {
-    fs.writeFile(path.join(currentDir, paths[i]), strs[i], () => {
-      console.info(`[${path.join(currentDir, paths[i])}] was generated!`);
+    const filePath = path.join(currentDir, paths[i]);
+    const directoryPath = path.dirname(filePath);
+    if (!fs.existsSync(directoryPath)) {
+      fs.mkdirSync(directoryPath, { recursive: true });
+    }
+    fs.writeFile(filePath, strs[i], () => {
+      console.info(`[${filePath}] was generated!`);
     });
   }
 }


### PR DESCRIPTION
파일을 생성할 때 해당 경로가 존재하지 않으면 파일이 생성되지 않음에도 불구하고 `[${filePath}] was generated!` 문구가 출력되는 문제가 있어 폴더를 만들도록 수정합니다.